### PR TITLE
NOTASK/Several Fixes

### DIFF
--- a/mockxy-core/pom.xml
+++ b/mockxy-core/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>io.github.pabloubal</groupId>
 	<artifactId>mockxy-core</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>mockxy-core</name>
 
@@ -29,6 +29,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.7</version>
 		</dependency>
 
 	</dependencies>

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/MockxyConfiguration.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/MockxyConfiguration.java
@@ -11,12 +11,14 @@ import io.github.pabloubal.mockxy.core.handlers.generic.SetCache;
 import io.github.pabloubal.mockxy.core.handlers.http.RemoteHTTPCall;
 import io.github.pabloubal.mockxy.core.handlers.socket.RemoteTCPCall;
 import io.github.pabloubal.mockxy.core.requests.Proxy;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MockxyConfiguration {
+
     @Bean
     public HandlerEnd handlerEnd(){
         return new HandlerEnd();
@@ -80,7 +82,7 @@ public class MockxyConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "proxy.cache.strategy", havingValue = "FileCache")
+    @ConditionalOnExpression("'${mockxy.cache.strategy:FileCache}' == 'FileCache'")
     public FileCache cacheStrategyFile(){
         return new FileCache();
     }

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/cache/strategies/impl/FileCache.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/cache/strategies/impl/FileCache.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class FileCache implements CacheStrategy {
-    @Value("${proxy.cache.baseDir}")
+    @Value("${mockxy.cache.baseDir}")
     private String baseDir;
 
     @PostConstruct

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/requests/HTTPHandler.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/requests/HTTPHandler.java
@@ -46,11 +46,24 @@ public class HTTPHandler implements Runnable {
             System.out.println(String.format("New HTTP connection"));
 
             firstLine = proxyToClientBr.readLine();
+
+            //Wait till ready
+            for(int i=0; i<10 && !proxyToClientBr.ready(); i++){
+                Thread.sleep(1);
+            }
+
             while ((tmpHdr = proxyToClientBr.readLine()).length() != 0) {
                 header.add(tmpHdr);
             }
 
+
             if(!firstLine.split(" ")[0].contains("GET")) {
+
+                //Wait till ready
+                for(int i=0; i<10 && !proxyToClientBr.ready(); i++){
+                    Thread.sleep(1);
+                }
+
                 while (proxyToClientBr.ready()) {
                     body += (char) proxyToClientBr.read();
                 }
@@ -64,7 +77,6 @@ public class HTTPHandler implements Runnable {
             req.getHeader().put(Constants.MAPPINGS_PROTOCOL, Constants.MAPPINGS_PROTO_HTTP);
             req.getHeader().put(Constants.HTTP_HEADER_METHOD, firstLine);
             req.setBody(body);
-
 
 
             Response resp = this.chainHandler.run(HandlerType.HTTP, req);
@@ -83,6 +95,8 @@ public class HTTPHandler implements Runnable {
             proxyToClientBw.close();
         }
         catch(IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
             e.printStackTrace();
         }
     }

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/requests/Proxy.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/requests/Proxy.java
@@ -15,10 +15,10 @@ public class Proxy{
     @Autowired
     ChainHandler chainHandler;
 
-    @Value("${proxy.httpPort}")
+    @Value("${mockxy.httpPort:8000}")
     private Integer httpPort;
 
-    @Value("${proxy.socksPort}")
+    @Value("${mockxy.socksPort:3001}")
     private Integer socksPort;
 
     private Thread httpThread;

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/requests/SOCKSHandler.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/requests/SOCKSHandler.java
@@ -59,8 +59,10 @@ public class SOCKSHandler implements Runnable {
             }
 
             System.out.println(String.format("New SOCKS connection to %s:%d",this.getIpAddress(), this.getPort()));
-            while (proxyToClientBr.ready()) {
-                message += (char) proxyToClientBr.read();
+
+            //Wait till ready
+            for(int i=0; i<10 && !proxyToClientBr.ready(); i++){
+                Thread.sleep(1);
             }
 
             Request req = new Request();
@@ -87,6 +89,8 @@ public class SOCKSHandler implements Runnable {
 
         }
         catch(IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
             e.printStackTrace();
         }
     }

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/utils/Mapping.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/utils/Mapping.java
@@ -2,6 +2,7 @@ package io.github.pabloubal.mockxy.core.utils;
 
 public class Mapping {
     private String dir;
+    private MappingType type;
     private Boolean matchHeaders = true;
     private Integer timeout = 3000;
 
@@ -29,6 +30,19 @@ public class Mapping {
 
     public void setTimeout(Integer timeout) {
         this.timeout = timeout;
+    }
+
+    public MappingType getType() {
+        return type;
+    }
+
+    public void setType(MappingType type) {
+        this.type = type;
+    }
+
+    public enum MappingType{
+        TCP,
+        HTTP
     }
 
 }

--- a/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/utils/MockxyProxySelector.java
+++ b/mockxy-core/src/main/java/io/github/pabloubal/mockxy/core/utils/MockxyProxySelector.java
@@ -1,0 +1,27 @@
+package io.github.pabloubal.mockxy.core.utils;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockxyProxySelector extends ProxySelector {
+
+    ArrayList<Proxy> noProxy = new ArrayList<Proxy>();
+
+    public MockxyProxySelector(){
+        noProxy.add(Proxy.NO_PROXY);
+    }
+
+    @Override
+    public List<Proxy> select(URI uri) {
+        return noProxy;
+    }
+
+    @Override
+    public void connectFailed(URI uri, SocketAddress socketAddress, IOException e) {
+    }
+}

--- a/mockxy-core/src/main/resources/application.yml
+++ b/mockxy-core/src/main/resources/application.yml
@@ -1,21 +1,3 @@
-proxy:
-  mappings:
-    GET AIF:
-      dir: ace
-      timeout: 500
-    tab-auth-api:
-      host: http://tab-auth-api.int.hotelbeds.com
-      dir: tab-auth-api
-
-  cache:
-    strategy: FileCache
-    baseDir: /home/pablo/tmp
-
-  tcpSeparator: "-"
-
-  httpPort: 8000
-  socksPort: 1080
-
 spring:
   main:
     web-environment: false

--- a/mockxy-core/src/test/java/io/github/pabloubal/mockxy/core/MockxyApplicationTests.java
+++ b/mockxy-core/src/test/java/io/github/pabloubal/mockxy/core/MockxyApplicationTests.java
@@ -1,17 +1,48 @@
 package io.github.pabloubal.mockxy.core;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class MockxyApplicationTests {
 
+    @Before
+    public void setup(){
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "8000");
+
+        System.setProperty("socksProxyHost", "localhost");
+        System.setProperty("socksProxyPort", "1080");
+        System.setProperty("socksNonProxyHosts", "httpbin*");
+    }
+
 	@Test
-	public void contextLoads() {
-	}
+	public void get() {
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> responseEntity = restTemplate.getForEntity("http://httpbin.org/get", String.class);
+
+        Assert.assertEquals(200, responseEntity.getStatusCodeValue());
+
+    }
+
+    @Test
+    public void post() {
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity("http://httpbin.org/post", "{\"test\": \"TEST\"}", String.class);
+
+        Assert.assertEquals(200, responseEntity.getStatusCodeValue());
+        Assert.assertTrue(responseEntity.getBody().contains("{\\\"test\\\": \\\"TEST\\\"}"));
+
+    }
 
 }
 

--- a/mockxy-core/src/test/resources/application.yml
+++ b/mockxy-core/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+mockxy:
+  mappings:
+    TCP HEADER:
+      dir: tcpHeader
+      type: TCP
+      timeout: 500
+    httpbin:
+      dir: httpbin
+      type: HTTP
+
+  cache:
+    strategy: FileCache
+    baseDir: /tmp
+
+  httpPort: 8000
+  socksPort: 1080

--- a/mockxy-core/target/classes/application.yml
+++ b/mockxy-core/target/classes/application.yml
@@ -1,21 +1,3 @@
-proxy:
-  mappings:
-    GET AIF:
-      dir: ace
-      timeout: 500
-    tab-auth-api:
-      host: http://tab-auth-api.int.hotelbeds.com
-      dir: tab-auth-api
-
-  cache:
-    strategy: FileCache
-    baseDir: /home/pablo/tmp
-
-  tcpSeparator: "-"
-
-  httpPort: 8000
-  socksPort: 1080
-
 spring:
   main:
     web-environment: false

--- a/mockxy-starter/pom.xml
+++ b/mockxy-starter/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>io.github.pabloubal</groupId>
 	<artifactId>mockxy-spring-boot-starter</artifactId>
-	<version>0.0.9-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<name>mockxy-spring-boot-starter</name>
 
 	<licenses>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.github.pabloubal</groupId>
             <artifactId>mockxy-core</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
- JDK-8144008 : Setting NO_PROXY on HTTP URL connections does not stop proxying: https://bugs.java.com/bugdatabase/view_bug.do%3Fbug_id%3DJDK-8144008
- Check socket ready before start reading
- Automatically set http and socks proxy to JVM on spring-boot-starter
- Automatically set socksNonProxyHosts for HTTP endpoints configured under mockxy
- Removed unnecesary information from application.yml
- Added simple test. Needs more work in order to unit test the whole artifact